### PR TITLE
Fixes `ReferenceError: sanatize is not defined`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "express-session-rsdb",
-  "version": "0.1.2",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -363,9 +363,9 @@
       }
     },
     "rocket-store": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/rocket-store/-/rocket-store-0.10.4.tgz",
-      "integrity": "sha512-dR1laH6HIKCOLw/0qCZrDkyMKkXEn2KGimJ4Db4K0Cbev8PB1mmnJgb3/e5xjWFrlxxzS3E2zbhvtd3Jxy5LQA==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/rocket-store/-/rocket-store-0.10.5.tgz",
+      "integrity": "sha512-xfBLh6RpxLQjeHx9sgv+xKV7iGflbeM77tG6VtGmCu8KcNymBrfJrdu/fy7iVxXD3fXsKxFmXCT8o5oMO1KwNQ==",
       "requires": {
         "fs-extra": ">8.0",
         "glob-to-regexp": ">0.4.0",
@@ -383,9 +383,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sanitize-filename": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz",
-      "integrity": "sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
       "requires": {
         "truncate-utf8-bytes": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "express": ">4.0",
     "express-session": ">1.5",
     "fs-extra": ">8.0",
-    "rocket-store": ">0.10.3"
+    "rocket-store": ">0.10.4"
   }
 }


### PR DESCRIPTION
Due a typo in the 0.10.4 version of [rocket-store](https://github.com/paragi/rocket-store-node) the above error is raised (only on windows)

The issue was already fixed in the rocket-store package (see: https://github.com/paragi/rocket-store-node/commit/e2cd914ea8c5b9d9b32ca5781e3898081333a1b4#diff-b454973841ddf98cfeaa6d8b6578f6bdL483) but this new version is not being used in this package.

This commit updates the version from 0.10.4 to the fixed version 0.10.5